### PR TITLE
Remove W3C from mobile brands to avoid W3 markup validator from being detected as mobile

### DIFF
--- a/lib/active_device/brand.rb
+++ b/lib/active_device/brand.rb
@@ -226,7 +226,6 @@ class Brand
     when /VK/i                 ; :VK
     when /Vodafone/i           ; :Vodafone
     when /Voxtel/i             ; :Voxtel
-    when /W3C/i                ; :W3C
     when /webOS/i              ; :Palm
     when /WellcoM/i            ; :WellcoM
     when /Wonu/i               ; :Wonu


### PR DESCRIPTION
I do not see why W3C was included in mobile brands. They do not make devices, but instead develop the standards for HTML/CSS. This was causing validator.w3.org to be detected as a mobile device by active_device, and it is not.
